### PR TITLE
Fixed production url

### DIFF
--- a/src/factory/goPay.ts
+++ b/src/factory/goPay.ts
@@ -11,7 +11,7 @@ import { createToken, handleError, with_gopay } from "../helpers";
 import { gopay } from "../types/gopay";
 
 export class GoPay {
-  public url: string = "https://gate.gopay.cz/api;";
+  public url: string = "https://gate.gopay.cz/api";
   public credentials: gopay.credentials;
   public __log: boolean;
 


### PR DESCRIPTION
In the production URL was `;`
I just removed it so you can use this lib properly 

🙂 